### PR TITLE
Add support for variable length integers to reduce file size even more

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -1,5 +1,5 @@
 module.exports = function decode() {
-  return (buffer, hasLUT, ArrayType) => {
+  return (buffer, VLI, hasLUT, ArrayType) => {
     var length = buffer.readUInt32LE(0),
         bytesPerElement = ArrayType.BYTES_PER_ELEMENT,
         FinalType = ArrayType,
@@ -22,8 +22,9 @@ module.exports = function decode() {
     
     var resultIndex = 0;
     while (resultIndex < length) {
-      let counter = buffer.readInt32LE(ind);
-      ind += 4;
+
+      let counter = VLI.decode(buffer, ind);
+      ind += VLI.byteCount(counter);
 
       let toRead = -counter;
       if (counter > 0) {

--- a/encode.js
+++ b/encode.js
@@ -1,5 +1,5 @@
 module.exports = function encode() {
-  return (arr, ResultType, resultTypeIndex) => {
+  return (arr, VLI, ResultType, resultTypeIndex) => {
     const MAX_LOOKUP_SIZE = 255;
     let result = [];
     result.push(new Uint32Array([arr.length]));
@@ -78,12 +78,12 @@ module.exports = function encode() {
           }
         }
 
-        result.push(new Int32Array([-(endRunIndex - i)]));
+        result.push(new Uint8Array(VLI.encode(-(endRunIndex - i))));
         result.push(new ResultType(arr.slice(i, endRunIndex)));
       }
       // it is a run, so just include a count and the value
       else {
-        result.push(new Int32Array([endRunIndex - i]));
+        result.push(new Uint8Array(VLI.encode(endRunIndex - i)));
         result.push(new ResultType([currentValue]));
       }
       i = endRunIndex - 1;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const StringArray = require('./stringArray');
 const inferArrayType = require('./inferArrayType');
+const variableLengthInteger = require('./variableLengthInteger');
 const decode = require('./decode');
 const encode = require('./encode');
 const vm = require('vm');
@@ -23,7 +24,7 @@ module.exports = {
   encode: (arr)  => {
     let ResultType = inferArrayType(arr),
         resultTypeIndex = DATA_TYPE_LOOKUP.indexOf(ResultType);
-    return typeOptimizedFunction(ENCODE_OPTIMIZATION_FN, resultTypeIndex, encode)(arr, ResultType, resultTypeIndex);
+    return typeOptimizedFunction(ENCODE_OPTIMIZATION_FN, resultTypeIndex, encode)(arr, variableLengthInteger, ResultType, resultTypeIndex);
   },
   decode: (buffer) => {
     var arrayTypeIndex = buffer.readUInt8(4),
@@ -36,6 +37,6 @@ module.exports = {
 
     var ArrayType = DATA_TYPE_LOOKUP[arrayTypeIndex];
 
-    return typeOptimizedFunction(DECODE_OPTIMIZATION_FN, arrayTypeIndex, decode)(buffer, hasLUT, ArrayType);
+    return typeOptimizedFunction(DECODE_OPTIMIZATION_FN, arrayTypeIndex, decode)(buffer, variableLengthInteger, hasLUT, ArrayType);
   }
 };

--- a/stringArray.js
+++ b/stringArray.js
@@ -1,10 +1,12 @@
+const variableLengthInteger = require('./variableLengthInteger');
+
 module.exports = class StringArray extends Array {
   constructor(o, offset, toRead) {
     if (Array.isArray(o)) {
       super(o.length);
 
       let s = o.length === 1 ? Buffer.from(String(o[0])) : Buffer.from(JSON.stringify(o));
-      this.buffer = Buffer.concat([Buffer.from(new Uint32Array([s.length]).buffer), s]);
+      this.buffer = Buffer.concat([variableLengthInteger.encode(s.length), s]);
       this.bytes = this.buffer.length;
       for (var i = 0; i < o.length; i++) {
         this[i] = o[i];
@@ -14,9 +16,10 @@ module.exports = class StringArray extends Array {
       super(toRead);
       o = Buffer.from(o);
       this.buffer = o;
-      let length = o.readUInt32LE(offset);
-      let s = String(o.slice(offset + 4, 4 + offset + length));
-      this.bytes = 4 + length;
+      let length = variableLengthInteger.decode(o, offset);
+      let lengthBytes = variableLengthInteger.byteCount(length);
+      let s = String(o.slice(offset + lengthBytes, lengthBytes + offset + length));
+      this.bytes = lengthBytes + length;
 
       if (toRead === 1) {
         this[0] = s;

--- a/variableLengthInteger.js
+++ b/variableLengthInteger.js
@@ -1,0 +1,90 @@
+const MAX_VALUE = 1<<30, SHIFT_SEVEN = 1<<7 ; // things get wonky after this point... plus it's a pretty huge number.
+
+module.exports = {
+  byteCount: function(value) {
+    let boundary = 1 << 6,
+        bytes = 1;
+    value = value < 0 ? -value : value;
+    while (value >= boundary) {
+      if (bytes <= 3) {
+        boundary <<= 7;
+      }
+      else {
+        boundary *= SHIFT_SEVEN;
+      }
+      bytes++;
+    }
+    return bytes;
+  },
+  encode: function(value) {
+    if (value > MAX_VALUE || value < -MAX_VALUE || !Number.isInteger(value)) {
+      throw 'INVALID';
+    }
+
+    var res = [],
+        mask = 63,
+        shift = 6,
+        isNegative = false;
+
+    if (value < 0) {
+      isNegative = true;
+      value = -value;
+    }
+    else if (value === 0) {
+      return Buffer.from(new Uint8Array([0]).buffer);
+    }
+  
+    while (value > 0) {
+      let p = value & mask;
+      p <<= 1;
+      value >>= shift;
+      if (value > 0) {
+        p |= 1;
+      }
+
+      if (res.length === 0) {
+        mask = 127;
+        shift = 7;
+        if (isNegative) {
+          p |= 128;
+        }
+      }
+      res.push(p);
+    }
+  
+    return Buffer.from(new Uint8Array(res).buffer);
+  },
+  decode: function(buffer, offset) {
+    var isNegative = false,
+        value = 0,
+        toShift = 0;
+
+    while (true) {
+      let byte = buffer.readUInt8(offset);
+
+      if (byte === 0 && toShift === 0) {
+        return 0;
+      }
+
+      // if this is the first byte, check the negative bit
+      if (toShift === 0) {
+        if (byte & 128) {
+          isNegative = true;
+          byte &= 127;
+        }
+      }
+
+      let hasMore = byte & 1;
+
+      value += byte >> 1 << toShift;
+      toShift += toShift ? 7 : 6;
+
+      if (!hasMore) {
+        break;
+      }
+      offset++;
+    }
+
+    return isNegative ? -value : value; 
+  }
+};


### PR DESCRIPTION
Run lengths were previously always 4-byte integers.  This is pretty inefficient in terms of space, so use smaller storage if possible