### PR TITLE
Reorganize binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:10.10
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+        
+      # run tests!
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![NPM Version][npm-image]][npm-url]
+[![NPM Downloads][downloads-image]][downloads-url]
+[![Test Coverage][circle-image]][circle-url]
+
+
 # orle
 `orle` (pronounced "Oh, really?") is simple **r**un **l**ength **e**ncoder for Javascript typed arrays.  
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,50 @@ Obviously your results may vary.  If you have a large array with entirely non-re
 # Format
 The binary format is pretty simple:
 
-| # of bytes| Purpose| Sample Value|
-|--------------------------------------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1| Data Version| 7|
-| 1| Data Type/Lookup Table Flag| The first 7 bits are an unsigned int representing different data formats.  Possible formats are: 0: Int32 1: Int16 2: Int8 3: Uint32 4: Uint16 5: Uint8 6: Float32 7: Float64 8: String  If the last bit is set, that indicates that a lookup table is present|
-| 1| The size of each "run" value| Unsigned int.   0: Int32 1: Int16 2: Int8|
-| <size of each run value>*<number of distinct runs + 1> | Store each set of runs of values| Positive values indicates that the value is repeated that number of times.  Negative values indicates that there is a run of distinct values.  0 indicates there are no more runs defined|
-| 1| The number of items in the LUT (if the LUT bit was set) | 12|
-| <size of each LUT value>*<number of items in LUT>| Actual lookup table values| new Uint16Array([360,120,30])|
-| <size of each value>*<number of values stored>| Actual payload|  Important notes: The order here is very important and has to map to the runs previously defined.  If a run is "positive" then the item should only appear once here.  Note on strings: Strings are stored as a Uint32LE number representing followed by that number of bytes of a JSON representation of the string array.  Note on Lookup Tables: If a lookup table is being used, the size of each value will be 1 and it will be a Uint8 value representing the value to use from the lookup table. |
+### Data Version
+**Bytes**: 1
+**Sample Value**: 7
+
+
+### Data Type/Lookup Table Flag
+**Bytes**: 1
+**Sample Value**: The first 7 bits are an unsigned int representing different data formats.  Possible formats are: 
+* 0: Int32 
+* 1: Int16 
+* 2: Int8 
+* 3: Uint32 
+* 4: Uint16 
+* 5: Uint8 
+* 6: Float32 
+* 7: Float64 
+* 8: String  
+
+If the last bit is set, that indicates that a lookup table is present
+
+### Run Value Size
+**Bytes**: 1
+**Sample Value**: The size of each "run" value.  Unsigned 8 bit int:
+* 0: Int32 
+* 1: Int16 
+* 2: Int8 
+
+### Runs
+**Bytes**: `size-of-each-run-value * (number-of-distinct-runs+1)`
+**Sample Value**: Store each set of run values.  Positive values indicates that the value is repeated that number of times.  Negative values indicates that there is a run of distinct values.  0 indicates there are no more runs defined
+
+### Lookup Table Length
+**Bytes**: 0 or 1
+**Sample Value**: If the lookup table bit was set, this indicates how many items are in the LUT (max of 256)
+
+### Lookup Table
+**Bytes**: `size-of-each-LUT-value * number-of-items-in-LUT`
+**Sample Value**: The data is serialized flat and is obviously variable length.  There are a maximum of 256 values in the lookup table.  If a Lookup table is used, the payload items are serialized as Uint8s indicating the index into this array that they map to
+
+### Payload
+**Bytes**: `size-of-each-value * number-of-values-stored`
+**Sample Value**: The actual payload.  Important notes:
+The order here is very important and has to map to the runs previously defined.  If a run is "positive" then the item should only appear once here.  
+**Note on strings:** Strings are stored as a Uint32LE number representing followed by that number of bytes of a JSON representation of the string array.  
+**Note on Lookup Tables:** If a lookup table is being used, the size of each value will be 1 and it will be a Uint8 value representing the value to use from the lookup table.
+
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-[![NPM Version][npm-image]][npm-url]
-[![NPM Downloads][downloads-image]][downloads-url]
-[![Test Coverage][circle-image]][circle-url]
-
+[![npm version](https://badge.fury.io/js/orle.svg)](https://badge.fury.io/js/orle)
+[![CircleCI](https://circleci.com/gh/jbreckman/orle.svg?style=svg)](https://circleci.com/gh/jbreckman/orle)
 
 # orle
 `orle` (pronounced "Oh, really?") is simple **r**un **l**ength **e**ncoder for Javascript typed arrays.  

--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ const arr = orle.decode(buffer);
 
 # Compression
 Obviously your results may vary.  If you have a large array with entirely non-repeating numbers, this will add about 9 bytes to the total payload.  If you have a large array of entirely repeating numbers, the resulting payload will be about 10 bytes.
+
+# Format
+The binary format is pretty simple:
+
+| # of bytes| Purpose| Sample Value|
+|--------------------------------------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1| Data Version| 7|
+| 1| Data Type/Lookup Table Flag| The first 7 bits are an unsigned int representing different data formats.  Possible formats are: 0: Int32 1: Int16 2: Int8 3: Uint32 4: Uint16 5: Uint8 6: Float32 7: Float64 8: String  If the last bit is set, that indicates that a lookup table is present|
+| 1| The size of each "run" value| Unsigned int.   0: Int32 1: Int16 2: Int8|
+| <size of each run value>*<number of distinct runs + 1> | Store each set of runs of values| Positive values indicates that the value is repeated that number of times.  Negative values indicates that there is a run of distinct values.  0 indicates there are no more runs defined|
+| 1| The number of items in the LUT (if the LUT bit was set) | 12|
+| <size of each LUT value>*<number of items in LUT>| Actual lookup table values| new Uint16Array([360,120,30])|
+| <size of each value>*<number of values stored>| Actual payload|  Important notes: The order here is very important and has to map to the runs previously defined.  If a run is "positive" then the item should only appear once here.  Note on strings: Strings are stored as a Uint32LE number representing followed by that number of bytes of a JSON representation of the string array.  Note on Lookup Tables: If a lookup table is being used, the size of each value will be 1 and it will be a Uint8 value representing the value to use from the lookup table. |

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 10

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 10

--- a/encode.js
+++ b/encode.js
@@ -1,9 +1,8 @@
 module.exports = function encode() {
-  return (arr, ResultType, resultTypeIndex) => {
+  return (version, arr, ResultType, resultTypeIndex) => {
     const MAX_LOOKUP_SIZE = 255;
-    let result = [];
-    result.push(new Uint32Array([arr.length]));
-
+    let result = [new Uint8Array([version])];
+    
     let flags = resultTypeIndex;
 
     //
@@ -13,7 +12,8 @@ module.exports = function encode() {
     let resultSet = new Set(),
         lastValue = null,
         valuesSeen = 0,
-        lookupMap = null;
+        lookupMap = null,
+        lookupTableArray = null;
 
     for (let i = 0; i < arr.length; i++) {
       if (arr[i] !== lastValue) {
@@ -42,8 +42,8 @@ module.exports = function encode() {
         arr[j] = lookupMap[oldArr[j]];
       }
 
-      result.push(new Uint8Array([flags | 128, lookupArray.length]));
-      result.push(new ResultType(lookupArray));
+      result.push(new Uint8Array([flags | 128]));
+      lookupTableArray =  new ResultType(lookupArray);
 
       ResultType = Uint8Array;
     }
@@ -54,6 +54,11 @@ module.exports = function encode() {
         arr = new ResultType([...arr]);
       }
     }
+
+    let runs = [],
+        valueArrays = [],
+        maxRunLength = 0,
+        minRunLength = 0;
 
     //
     // Actually encode
@@ -69,6 +74,9 @@ module.exports = function encode() {
         }
       }
 
+      let runLength = null,
+          runArrayValue = null;
+
       // this is not a run, so see how many numbers are not a run
       if (endRunIndex === i + 1) {
         for (; endRunIndex < arr.length; endRunIndex++) {
@@ -78,15 +86,55 @@ module.exports = function encode() {
           }
         }
 
-        result.push(new Int32Array([-(endRunIndex - i)]));
-        result.push(new ResultType(arr.slice(i, endRunIndex)));
+        runLength = -(endRunIndex - i);
+        runArrayValue = new ResultType(arr.slice(i, endRunIndex));
       }
       // it is a run, so just include a count and the value
       else {
-        result.push(new Int32Array([endRunIndex - i]));
-        result.push(new ResultType([currentValue]));
+        runLength = endRunIndex - i;
+        runArrayValue = new ResultType([currentValue]);
       }
+
+      runs.push(runLength);
+      valueArrays.push(runArrayValue);
+
+      if (runLength > maxRunLength) {
+        maxRunLength = runLength;
+      }
+      if (runLength < minRunLength) {
+        minRunLength = runLength;
+      }
+
       i = endRunIndex - 1;
+    }
+
+    // indicates the run lengths are done
+    runs.push(0);
+
+    // figure out the data type to store our run lengths
+    if (minRunLength < -32768 || maxRunLength >= 32768) {
+      result.push(new Uint8Array([0])); // 32 bit array
+      result.push(new Int32Array(runs));
+    }
+    else if (minRunLength < -128 || maxRunLength >= 128) {
+      result.push(new Uint8Array([1])); // 16 bit array
+      result.push(new Int16Array(runs));
+    }
+    else {
+      result.push(new Uint8Array([2])); // 8 bit array
+      result.push(new Int8Array(runs));
+    }
+
+    if (lookupTableArray) {
+      result.push(new Uint8Array([lookupTableArray.length]));
+      result.push(lookupTableArray);
+    }
+
+    if (ResultType.join) {
+      result.push(ResultType.join(valueArrays));
+    }
+    else {
+      result = result.concat(valueArrays);
     }
 
     return Buffer.concat(result.map(d => Buffer.from(d.buffer)));

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const vm = require('vm');
 const DATA_TYPE_LOOKUP = [ Int32Array, Int16Array, Int8Array, Uint32Array, Uint16Array, Uint8Array, Float32Array, Float64Array, StringArray ];
 const ENCODE_OPTIMIZATION_FN = [];
 const DECODE_OPTIMIZATION_FN = [];
+const DATA_VERSION = 7;
 
 function typeOptimizedFunction(cache, index, originalFn) {
   // v8 optimization does quite poorly if different array types
@@ -23,11 +24,16 @@ module.exports = {
   encode: (arr)  => {
     let ResultType = inferArrayType(arr),
         resultTypeIndex = DATA_TYPE_LOOKUP.indexOf(ResultType);
-    return typeOptimizedFunction(ENCODE_OPTIMIZATION_FN, resultTypeIndex, encode)(arr, ResultType, resultTypeIndex);
+    return typeOptimizedFunction(ENCODE_OPTIMIZATION_FN, resultTypeIndex, encode)(DATA_VERSION, arr, ResultType, resultTypeIndex);
   },
   decode: (buffer) => {
-    var arrayTypeIndex = buffer.readUInt8(4),
+    var dataVersion = buffer.readUInt8(0),
+        arrayTypeIndex = buffer.readUInt8(1),
         hasLUT = false;
+
+    if (DATA_VERSION !== dataVersion) {
+      throw 'INVALID';
+    } 
 
     if (arrayTypeIndex & 128) {
       hasLUT = true;
@@ -36,6 +42,6 @@ module.exports = {
 
     var ArrayType = DATA_TYPE_LOOKUP[arrayTypeIndex];
 
-    return typeOptimizedFunction(DECODE_OPTIMIZATION_FN, arrayTypeIndex, decode)(buffer, hasLUT, ArrayType);
+    return typeOptimizedFunction(DECODE_OPTIMIZATION_FN, buffer.readUInt16LE(1), decode)(buffer, hasLUT, ArrayType);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orle",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "RLE array encoder/decoder",
   "main": "index.js",
   "scripts": {

--- a/stringArray.js
+++ b/stringArray.js
@@ -1,32 +1,27 @@
 module.exports = class StringArray extends Array {
+
+  static join(arr) {
+    return new StringArray([].concat.apply([], arr));
+  }
+
   constructor(o, offset, toRead) {
     if (Array.isArray(o)) {
       super(o.length);
-
-      let s = o.length === 1 ? Buffer.from(String(o[0])) : Buffer.from(JSON.stringify(o));
+      let s = Buffer.from(JSON.stringify(o));
       this.buffer = Buffer.concat([Buffer.from(new Uint32Array([s.length]).buffer), s]);
       this.bytes = this.buffer.length;
-      for (var i = 0; i < o.length; i++) {
+      for (let i = 0; i < o.length; i++) {
         this[i] = o[i];
       }
     }
     else if (o instanceof ArrayBuffer) {
-      super(toRead);
       o = Buffer.from(o);
-      this.buffer = o;
       let length = o.readUInt32LE(offset);
       let s = String(o.slice(offset + 4, 4 + offset + length));
+      let arr = JSON.parse(s);
+      super(...arr);
+      this.buffer = o;
       this.bytes = 4 + length;
-
-      if (toRead === 1) {
-        this[0] = s;
-      }
-      else {
-        let arr = JSON.parse(s);
-        for (var i = 0; i < arr.length; i++) {
-          this[i] = arr[i];
-        }
-      }
     }
     else if (Number.isFinite(o)) {
       super(o);

--- a/test.js
+++ b/test.js
@@ -3,9 +3,10 @@ const orle = require('./index');
 
 t.test('encode/decode', t => {
 
-  function confirm(t, arr, itemCount, itemSize, transitions) {
+  function confirm(t, arr, itemCount, itemSize, transitions, transitionSize) {
+    transitionSize = transitionSize || 1;
     var encoded = orle.encode(arr);
-    var expectedSize = 5 + itemCount*itemSize + transitions*4;
+    var expectedSize = 3 + itemCount*itemSize + (transitions+1)*transitionSize;
     t.same(encoded.length, expectedSize, 'correct size');
     t.same([...orle.decode(encoded)], [...arr], 'correct values');
     t.end();
@@ -29,10 +30,11 @@ t.test('encode/decode', t => {
 
 t.test('string encode/decode', t => {
 
-  function confirm(t, arr, itemCount, totalItemSize, transitions, singleElementArrayCount) {
+  function confirm(t, arr, itemCount, totalItemSize, transitions, transitionSize) {
+    transitionSize = transitionSize || 1;
     var encoded = orle.encode(arr);
 
-    var expectedSize = 5 /* header size */ + itemCount*3 /* handle "", between elements */ + totalItemSize + transitions*9 /* each transition has a 4 byte length, 4 byte count, and 2 bytes for [] */ - singleElementArrayCount * 4 /* single string arrays aren't stored as arrays */;
+    var expectedSize = 3 /* header size */ + 4 /* length of string payload */ + itemCount*3 /* handle "", between elements */ + totalItemSize + 2 /* [] before and after */ - 1 /* last , isn't there */ + (transitions+1)*transitionSize /* each transition has a 4 byte length, 4 byte count, and 2 bytes for [] */;
     t.same(encoded.length, expectedSize, 'correct size');
     t.same([...orle.decode(encoded)], [...arr], 'correct values');
     t.end();
@@ -48,13 +50,68 @@ t.test('string encode/decode', t => {
         S4_LENGTH = S4.length;
 
   t.test('single run', t => confirm(t, [S2, S2, S2], 1, S2_LENGTH, 1, 1));
-  t.test('non-uniform run', t => confirm(t, [S1, S2, S3], 3, S1_LENGTH + S2_LENGTH + S3_LENGTH, 1, 0));
-  t.test('test basic strings', t => confirm(t, [S1, S2, S2, S2], 2, S1_LENGTH + S2_LENGTH, 2, 2));
+  t.test('non-uniform run', t => confirm(t, [S1, S2, S3], 3, S1_LENGTH + S2_LENGTH + S3_LENGTH, 1, 1));
+  t.test('test basic strings', t => confirm(t, [S1, S2, S2, S2], 2, S1_LENGTH + S2_LENGTH, 2, 1));
   t.test('empty strings', t => confirm(t, [S4, S4, S4], 1, S4_LENGTH, 1, 1));
-  t.test('non-uniform run with empty string', t => confirm(t, [S1, S2, S3, S4], 4, S1_LENGTH + S2_LENGTH + S3_LENGTH, 1, 0));
-  t.test('run then non-uniform', t => confirm(t, [S3, S3, S3, S3, S1, S2, S3, S4, S3, S3, S3], 6, S1_LENGTH + S2_LENGTH + S3_LENGTH + S3_LENGTH + S3_LENGTH, 3, 2));
+  t.test('non-uniform run with empty string', t => confirm(t, [S1, S2, S3, S4], 4, S1_LENGTH + S2_LENGTH + S3_LENGTH, 1, 1));
+  t.test('run then non-uniform', t => confirm(t, [S3, S3, S3, S3, S1, S2, S3, S4, S3, S3, S3], 6, S1_LENGTH + S2_LENGTH + S3_LENGTH + S3_LENGTH + S3_LENGTH, 3, 1));
   t.end();
 });
+
+t.test('string lookup tables', t => {
+
+  const S1 = 'how are you',
+        S1_LENGTH = S1.length,
+        S2 = 'i am good',
+        S2_LENGTH = S2.length,
+        S3 = 'test',
+        S3_LENGTH = S3.length,
+        S4 = '',
+        S4_LENGTH = S4.length;
+
+  function confirm(t, arr, itemCount, totalItemSize, totalElements, transitions, transitionSize) {
+    var encoded = orle.encode(arr);
+    var expectedSize = 3 /* header size */ + 1 /* LUT length */ + 4 /* length of string payload */ + totalItemSize + itemCount*3 /* handle "", between elements */ + 2 /* [] before and after */ - 1 /* last , isn't there */ + (transitions+1)*transitionSize /* each transition has a 4 byte length, 4 byte count, and 2 bytes for [] */ + totalElements;
+    t.same(encoded.length, expectedSize, `correct size (${expectedSize})`);
+    t.same([...orle.decode(encoded)], [...arr], 'correct values');
+    t.end();
+  }
+  function dupeArray(arr, count) {
+    var res = [];
+    for (var i = 0; i < count; i++) {
+      res = res.concat(arr);
+    }
+    return res;
+  }
+
+  t.test('small run', t => confirm(t, dupeArray([S1, S2, S3], 10), 3, S1_LENGTH + S2_LENGTH + S3_LENGTH, 30, 1, 1));
+  t.test('simple run', t => confirm(t, dupeArray([S1, S2, S3], 100), 3, S1_LENGTH + S2_LENGTH + S3_LENGTH, 300, 1, 2));
+  t.test('non-uniform run', t => confirm(t, dupeArray([S1, S2, S3, S4, S4], 100), 4, S4_LENGTH + S1_LENGTH + S2_LENGTH + S3_LENGTH, 400, 200, 1));
+  t.end();
+});
+
+
+t.test('lookup tables', t => {
+
+  function confirm(t, arr, itemCount, itemSize, totalElements, transitions, transitionSize) {
+    transitionSize = transitionSize || 1;
+    var encoded = orle.encode(arr);
+    var expectedSize = 3 + 1 + itemCount*itemSize + (transitions+1)*transitionSize + totalElements;
+    t.same(encoded.length, expectedSize, `correct size (${expectedSize})`);
+    t.same([...orle.decode(encoded)], [...arr], 'correct values');
+    t.end();
+  }
+
+  t.test('test uint32', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,100000], 5, 4, 25, 13));
+  t.test('test uint32 long run', t => confirm(t, [100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000], 3, 4, 24, 1));
+  t.test('test int32', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,-100000], 5, 4, 25, 13));
+  t.test('test uint16', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1000], 5, 2, 25, 13));
+  t.test('test int16', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,-1000], 5, 2, 25, 13));
+  t.test('test float64', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1000.01], 5, 8, 25, 13));
+  t.end();
+});
+
+
 
 t.test('performance', t => {
 
@@ -100,62 +157,9 @@ t.test('performance', t => {
   t.test('very large encoding/decoding known data format one big run', t => timeTestData(t, new Uint32Array(buildTestData(1, 0, 5000000)), 150, 50));
   t.test('very large encoding/decoding known data format', t => timeTestData(t, new Uint32Array(buildTestData(1000, 5000, 500)), 150, 50));
   t.test('very large mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 50000, 0)), 150, 50));
-  t.test('medium mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 500, 50)), 10, 10));
+  t.test('medium mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 500, 50)), 30, 10));
   t.test('pathological case', t => timeTestData(t, new Uint32Array(buildTestData(10000, 2, 3)), 100, 400));
-  t.test('one long run of strings', t => timeTestData(t, buildStringTestData(1, 0, 100000), 100, 50));
+  t.test('one long run of strings', t => timeTestData(t, buildStringTestData(1, 0, 100000), 150, 50));
   t.test('strings mixed', t => timeTestData(t, buildStringTestData(100, 500, 500), 100, 50));
-  t.end();
-});
-
-
-t.test('lookup tables', t => {
-
-  function confirm(t, arr, itemCount, itemSize, totalElements, transitions) {
-    var encoded = orle.encode(arr);
-    var expectedSize = 5 + 1 + itemCount*itemSize + transitions*4 + totalElements;
-    t.same(encoded.length, expectedSize, `correct size (${expectedSize})`);
-    t.same([...orle.decode(encoded)], [...arr], 'correct values');
-    t.end();
-  }
-
-  t.test('test uint32', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,100000], 5, 4, 25, 13));
-  t.test('test uint32 long run', t => confirm(t, [100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000,100000,200000,300000], 3, 4, 24, 1));
-  t.test('test int32', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,-100000], 5, 4, 25, 13));
-  t.test('test uint16', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1000], 5, 2, 25, 13));
-  t.test('test int16', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,-1000], 5, 2, 25, 13));
-  t.test('test float64', t => confirm(t, [1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1,2,3,4,4,1000.01], 5, 8, 25, 13));
-  t.end();
-});
-
-
-t.test('string lookup tables', t => {
-
-  const S1 = 'how are you',
-        S1_LENGTH = S1.length,
-        S2 = 'i am good',
-        S2_LENGTH = S2.length,
-        S3 = 'test',
-        S3_LENGTH = S3.length,
-        S4 = '',
-        S4_LENGTH = S4.length;
-
-  function confirm(t, arr, itemCount, totalItemSize, totalElements, transitions, singleElementArrayCount) {
-    var encoded = orle.encode(arr);
-    var expectedSize = 5 + 1 + 4 + itemCount*3 - 1 + 2 + totalItemSize + transitions*4 + totalElements - singleElementArrayCount*4;
-    t.same(encoded.length, expectedSize, `correct size (${expectedSize})`);
-    t.same([...orle.decode(encoded)], [...arr], 'correct values');
-    t.end();
-  }
-  function dupeArray(arr, count) {
-    var res = [];
-    for (var i = 0; i < count; i++) {
-      res = res.concat(arr);
-    }
-    return res;
-  }
-
-  t.test('small run', t => confirm(t, dupeArray([S1, S2, S3], 10), 3, S1_LENGTH + S2_LENGTH + S3_LENGTH, 30, 1, 0));
-  t.test('simple run', t => confirm(t, dupeArray([S1, S2, S3], 100), 3, S1_LENGTH + S2_LENGTH + S3_LENGTH, 300, 1, 0));
-  t.test('non-uniform run', t => confirm(t, dupeArray([S1, S2, S3, S4, S4], 100), 4, S4_LENGTH + S1_LENGTH + S2_LENGTH + S3_LENGTH, 400, 200, 0));
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -159,7 +159,7 @@ t.test('performance', t => {
   t.test('very large mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 50000, 0)), 150, 50));
   t.test('medium mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 500, 50)), 30, 10));
   t.test('pathological case', t => timeTestData(t, new Uint32Array(buildTestData(10000, 2, 3)), 100, 400));
-  t.test('one long run of strings', t => timeTestData(t, buildStringTestData(1, 0, 100000), 150, 50));
+  t.test('one long run of strings', t => timeTestData(t, buildStringTestData(1, 0, 100000), 250, 50));
   t.test('strings mixed', t => timeTestData(t, buildStringTestData(100, 500, 500), 100, 50));
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -158,8 +158,8 @@ t.test('performance', t => {
   t.test('very large encoding/decoding known data format', t => timeTestData(t, new Uint32Array(buildTestData(1000, 5000, 500)), 150, 50));
   t.test('very large mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 50000, 0)), 150, 50));
   t.test('medium mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 500, 50)), 30, 10));
-  t.test('pathological case', t => timeTestData(t, new Uint32Array(buildTestData(10000, 2, 3)), 100, 400));
-  t.test('one long run of strings', t => timeTestData(t, buildStringTestData(1, 0, 100000), 250, 50));
+  t.test('pathological case', t => timeTestData(t, new Uint32Array(buildTestData(10000, 2, 3)), 100, 50));
+  t.test('one long run of strings', t => timeTestData(t, buildStringTestData(1, 0, 100000), 250, 100));
   t.test('strings mixed', t => timeTestData(t, buildStringTestData(100, 500, 500), 100, 50));
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -160,6 +160,6 @@ t.test('performance', t => {
   t.test('medium mostly long runs', t => timeTestData(t, new Uint32Array(buildTestData(100, 500, 50)), 30, 10));
   t.test('pathological case', t => timeTestData(t, new Uint32Array(buildTestData(10000, 2, 3)), 100, 50));
   t.test('one long run of strings', t => timeTestData(t, buildStringTestData(1, 0, 100000), 250, 100));
-  t.test('strings mixed', t => timeTestData(t, buildStringTestData(100, 500, 500), 100, 50));
+  t.test('strings mixed', t => timeTestData(t, buildStringTestData(100, 500, 500), 150, 50));
   t.end();
 });


### PR DESCRIPTION
Store the data in a way that is much faster to deserialize and also more compact.  The entire "values" array is stored in one chunk now, and the entire "runs" values are stored in one chunk now.  So both can be read in one go.